### PR TITLE
Fix menu dismissal bug in GUI config editor (clean implementation)

### DIFF
--- a/gui/config_editor.py
+++ b/gui/config_editor.py
@@ -223,26 +223,31 @@ class ConfigEditor:
             
     def file_menu(self):
         menu = tk.Menu(self.root, tearoff=0, bg='#404040', fg='white')
-        menu.add_command(label="Ouvrir config", command=self.open_config)
-        menu.add_command(label="Sauvegarder", command=self.save_config)
-        menu.add_command(label="Sauvegarder sous...", command=self.save_config_as)
+        menu.add_command(label="Ouvrir config", command=lambda: self._menu_command(menu, self.open_config))
+        menu.add_command(label="Sauvegarder", command=lambda: self._menu_command(menu, self.save_config))
+        menu.add_command(label="Sauvegarder sous...", command=lambda: self._menu_command(menu, self.save_config_as))
         menu.add_separator()
-        menu.add_command(label="Quitter", command=self.root.quit)
+        menu.add_command(label="Quitter", command=lambda: self._menu_command(menu, self.root.quit))
         
         try:
             menu.tk_popup(self.root.winfo_pointerx(), self.root.winfo_pointery())
         finally:
-            menu.grab_release()
+            pass
             
     def edit_menu(self):
         menu = tk.Menu(self.root, tearoff=0, bg='#404040', fg='white')
-        menu.add_command(label="Réinitialiser", command=self.reset_config)
-        menu.add_command(label="Valeurs par défaut", command=self.load_defaults)
+        menu.add_command(label="Réinitialiser", command=lambda: self._menu_command(menu, self.reset_config))
+        menu.add_command(label="Valeurs par défaut", command=lambda: self._menu_command(menu, self.load_defaults))
         
         try:
             menu.tk_popup(self.root.winfo_pointerx(), self.root.winfo_pointery())
         finally:
-            menu.grab_release()
+            pass
+
+    def _menu_command(self, menu, command):
+        """Helper method to execute menu command and destroy menu"""
+        menu.destroy()
+        command()
             
     def help_menu(self):
         messagebox.showinfo("Aide", "Éditeur de configuration fyoutube\n\nUtilisez les onglets pour configurer les différents aspects du téléchargeur.")


### PR DESCRIPTION
# Fix menu dismissal bug in GUI config editor (clean implementation)

## Summary

Fixes a GUI bug where popup menus (Fichier, Edition, Aide) would remain visible after clicking menu items instead of properly dismissing. This is a clean implementation of Martin's working solution applied to a fresh branch from main.

**Root Cause:** The original implementation used `menu.grab_release()` which released the mouse grab but didn't actually destroy the menu widgets, causing them to remain visible.

**Key Changes:**
- Added `_menu_command()` helper method that properly destroys menus before executing commands
- Updated `file_menu()` and `edit_menu()` to use lambda wrappers that call `_menu_command`
- Replaced `menu.grab_release()` with `pass` in finally blocks to avoid interference

## Review & Testing Checklist for Human

- [ ] **Launch GUI and verify basic functionality** - Run `python fyoutube.py guiconfig` to ensure GUI opens without errors
- [ ] **Test menu dismissal behavior** - Click each popup menu (Fichier, Edition, Aide) and verify they disappear after selecting items or clicking elsewhere  
- [ ] **Verify menu commands still work** - Test that menu items like "Sauvegarder", "Ouvrir config", "Réinitialiser" actually execute their intended functions
- [ ] **Test edge cases** - Try clicking multiple menus rapidly, clicking outside menus, and other interaction patterns to ensure no menu remains stuck

**⚠️ Critical Testing Note:** This fix was applied from Martin's working solution but could not be tested locally due to missing tkinter dependency. All changes are based on code review and Martin's verified fix.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    fyoutube["core/fyoutube.py"]
    config_editor["gui/config_editor.py"]:::major-edit
    config["core/Config.py"]
    
    fyoutube -->|"calls run_config()"| config
    config -->|"launches GUI"| config_editor
    
    subgraph "Menu Methods (Fixed)"
        file_menu["file_menu()"]:::major-edit
        edit_menu["edit_menu()"]:::major-edit
        helper["_menu_command()"]:::major-edit
    end
    
    config_editor --> file_menu
    config_editor --> edit_menu
    file_menu --> helper
    edit_menu --> helper
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB  
classDef context fill:#FFFFFF
```

### Notes

**Session Info:** 
- Requested by: Martin Belanger (@mbeware)
- Session URL: https://app.devin.ai/sessions/d48556c38aa84e2eacabed516e4b7dc3

**Implementation Details:**
- The fix uses a single point of control for menu destruction via the `_menu_command` helper
- Lambda functions ensure the menu reference is captured correctly for destruction
- This avoids the race condition that occurred in previous attempts where menus were being destroyed in multiple places

**Risk Assessment:** YELLOW - Focused change based on verified working solution, but completely untested due to environment limitations. GUI timing/threading issues can be subtle and the menu dismissal logic needs real user interaction testing to validate.